### PR TITLE
Fail CI on compile warnings

### DIFF
--- a/.github/workflows/elixir-build-and-test.yml
+++ b/.github/workflows/elixir-build-and-test.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}
-          build-flags: --all-warnings
+          build-flags: --all-warnings --warnings-as-errors
 
       - name: Run Migrations
         run: mix ecto.migrate

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :ex_audit, ExAudit.Test.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/ex_audit.ex
+++ b/lib/ex_audit.ex
@@ -2,10 +2,8 @@ defmodule ExAudit do
   use Application
 
   def start(_, _) do
-    import Supervisor.Spec
-
     children = [
-      worker(ExAudit.CustomData, [])
+      ExAudit.CustomData
     ]
 
     opts = [strategy: :one_for_one, name: ExAudit.Supervisor]

--- a/lib/tracking/custom_data.ex
+++ b/lib/tracking/custom_data.ex
@@ -5,7 +5,7 @@ defmodule ExAudit.CustomData do
   ETS table that stores custom data for pids
   """
 
-  def start_link() do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,7 @@ defmodule ExAudit.Mixfile do
   def project do
     [
       description: "Ecto auditing library that transparently tracks changes and can revert them",
+      aliases: aliases(),
       app: :ex_audit,
       version: "0.9.0",
       elixir: "~> 1.11",
@@ -11,7 +12,10 @@ defmodule ExAudit.Mixfile do
       deps: deps(),
       elixirc_paths: paths(Mix.env()),
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [coveralls: :test],
+      preferred_cli_env: [
+        check: :test,
+        coveralls: :test
+      ],
       source_url: "https://github.com/zenneriot/ex_audit",
       package: [
         licenses: ["MIT"],
@@ -43,6 +47,16 @@ defmodule ExAudit.Mixfile do
     [
       mod: {ExAudit, []},
       extra_applications: [:logger]
+    ]
+  end
+
+  defp aliases do
+    [
+      check: [
+        "clean",
+        "compile --all-warnings --warnings-as-errors",
+        "test --warnings-as-errors",
+      ]
     ]
   end
 


### PR DESCRIPTION
Add flags to the CI compile step to treat warnings as errors, so that CI will fail if we introduce code that generates warnings.

Fix code that currently generates warnings.