### PR TITLE
Check formatting in CI

### DIFF
--- a/.github/workflows/elixir-quality-checks.yml
+++ b/.github/workflows/elixir-quality-checks.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Check for unused deps
         run: mix deps.unlock --check-unused
 
-      # - name: Check code formatting
-      #   run: mix format --check-formatted
-      #   # Check formatting even if there were unused deps so that
-      #   # we give devs as much feedback as possible & save some time.
-      #   if: always()
+      - name: Check code formatting
+        run: mix format --check-formatted
+        # Check formatting even if there were unused deps so that
+        # we give devs as much feedback as possible & save some time.
+        if: always()
 
       # - name: Run Credo
       #   run: mix credo suggest --min-priority=normal

--- a/lib/repo/queryable.ex
+++ b/lib/repo/queryable.ex
@@ -76,11 +76,11 @@ defmodule ExAudit.Queryable do
 
   def history_query(%{id: id, __struct__: struct}) do
     from(
-        v in version_schema(),
-        where: v.entity_id == ^id,
-        where: v.entity_schema == ^struct,
-        order_by: [desc: :recorded_at]
-      )
+      v in version_schema(),
+      where: v.entity_id == ^id,
+      where: v.entity_schema == ^struct,
+      order_by: [desc: :recorded_at]
+    )
   end
 
   @drop_fields [:__meta__, :__struct__]

--- a/mix.exs
+++ b/mix.exs
@@ -56,8 +56,9 @@ defmodule ExAudit.Mixfile do
         "clean",
         "deps.unlock --check-unused",
         "compile --all-warnings --warnings-as-errors",
+        "format --check-formatted",
         "deps.unlock --check-unused",
-        "test --warnings-as-errors",
+        "test --warnings-as-errors"
       ]
     ]
   end

--- a/test/ex_audit_test.exs
+++ b/test/ex_audit_test.exs
@@ -261,7 +261,7 @@ defmodule ExAuditTest do
     end
 
     test "returns a queryable", %{user: user} do
-     assert user |> Repo.history_query() |> Repo.all() |> Enum.count() == 1
+      assert user |> Repo.history_query() |> Repo.all() |> Enum.count() == 1
     end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,6 @@
 ExAudit.Test.Repo.start_link()
 Ecto.Adapters.SQL.Sandbox.mode(ExAudit.Test.Repo, :auto)
 
-
 migrations_path = Path.join([:code.priv_dir(:ex_audit), "repo", "migrations"])
 Ecto.Migrator.run(ExAudit.Test.Repo, migrations_path, :up, all: true)
 


### PR DESCRIPTION
In order to ensure consistently readable code, add a check to CI for code formatting via `mix format`.